### PR TITLE
Fix Slim SEO compatibility issue in Current_Site_Element

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -145,7 +145,8 @@
                 "patches/berlindb-core-src-database-column-php.patch"
             ],
             "jasny/sso": [
-                "patches/jasny-sso-src-broker-cookies-php.patch"
+                "patches/jasny-sso-src-broker-cookies-php.patch",
+                "patches/jasny-sso-php8-compatibility.patch"
             ]
         },
         "installer-paths": {

--- a/inc/ui/class-account-summary-element.php
+++ b/inc/ui/class-account-summary-element.php
@@ -294,9 +294,10 @@ class Account_Summary_Element extends Base_Element {
 	 */
 	public function output($atts, $content = null) {
 
-		// Defensive check - setup() may have been called but site can still be null
+		$this->ensure_setup();
+
+		// Return empty if no site available (e.g., during SEO processing)
 		if ( ! $this->site) {
-			_doing_it_wrong(__METHOD__, esc_html__('setup() or setup_preview() must be called before output().', 'multisite-ultimate'), wu_get_version());
 			return '';
 		}
 

--- a/inc/ui/class-base-element.php
+++ b/inc/ui/class-base-element.php
@@ -443,6 +443,19 @@ abstract class Base_Element {
 	public function setup_preview() {}
 
 	/**
+	 * Ensures setup is called before output to prevent errors.
+	 * 
+	 * @since 2.4.3
+	 * @return void
+	 */
+	protected function ensure_setup() {
+		if (!$this->loaded) {
+			$this->is_preview() ? $this->setup_preview() : $this->setup();
+			$this->loaded = true;
+		}
+	}
+
+	/**
 	 * Checks content to see if the current element is present.
 	 *
 	 * This check uses different methods, covering classic shortcodes,

--- a/inc/ui/class-billing-info-element.php
+++ b/inc/ui/class-billing-info-element.php
@@ -272,9 +272,10 @@ class Billing_Info_Element extends Base_Element {
 	 */
 	public function output($atts, $content = null) {
 
-		// Defensive check - setup() may have been called but membership can still be null
+		$this->ensure_setup();
+
+		// Return empty if no membership available (e.g., during SEO processing)
 		if ( ! $this->membership) {
-			_doing_it_wrong(__METHOD__, esc_html__('setup() or setup_preview() must be called before output().', 'multisite-ultimate'), wu_get_version());
 			return '';
 		}
 

--- a/inc/ui/class-current-site-element.php
+++ b/inc/ui/class-current-site-element.php
@@ -363,22 +363,22 @@ class Current_Site_Element extends Base_Element {
 				'label'        => __('Visit Site', 'multisite-ultimate'),
 				'icon_classes' => 'dashicons-wu-browser wu-align-text-bottom',
 				'classes'      => '',
-				'href'         => $this->site->get_active_site_url(),
+				'href'         => $this->site ? $this->site->get_active_site_url() : '',
 			],
 			'edit_site'  => [
 				'label'        => __('Edit Site', 'multisite-ultimate'),
 				'icon_classes' => 'dashicons-wu-edit wu-align-text-bottom',
 				'classes'      => 'wubox',
-				'href'         => wu_get_form_url(
+				'href'         => $this->site ? wu_get_form_url(
 					'edit_site',
 					[
 						'site' => $this->site->get_hash(),
 					]
-				),
+				) : '',
 			],
 		];
 
-		if ($atts['show_admin_link']) {
+		if ($atts['show_admin_link'] && $this->site) {
 			$actions['site_admin'] = [
 				'label'        => __('Admin Panel', 'multisite-ultimate'),
 				'icon_classes' => 'dashicons-wu-grid wu-align-text-bottom',

--- a/inc/ui/class-current-site-element.php
+++ b/inc/ui/class-current-site-element.php
@@ -352,9 +352,10 @@ class Current_Site_Element extends Base_Element {
 	 */
 	public function output($atts, $content = null) {
 
-		// Defensive check - setup() may have been called but site can still be null
+		$this->ensure_setup();
+
+		// Return empty if no site available (e.g., during SEO processing)
 		if ( ! $this->site) {
-			_doing_it_wrong(__METHOD__, esc_html__('setup() or setup_preview() must be called before output().', 'multisite-ultimate'), wu_get_version());
 			return '';
 		}
 

--- a/inc/ui/class-invoices-element.php
+++ b/inc/ui/class-invoices-element.php
@@ -274,9 +274,10 @@ class Invoices_Element extends Base_Element {
 	 */
 	public function output($atts, $content = null) {
 
-		// Defensive check - setup() may have been called but membership can still be null
+		$this->ensure_setup();
+
+		// Return empty if no membership available (e.g., during SEO processing)
 		if ( ! $this->membership) {
-			_doing_it_wrong(__METHOD__, esc_html__('setup() or setup_preview() must be called before output().', 'multisite-ultimate'), wu_get_version());
 			return '';
 		}
 

--- a/inc/ui/class-limits-element.php
+++ b/inc/ui/class-limits-element.php
@@ -240,9 +240,10 @@ class Limits_Element extends Base_Element {
 	 */
 	public function output($atts, $content = null) {
 
-		// Defensive check - setup() may have been called but site can still be null
+		$this->ensure_setup();
+
+		// Return empty if no site available (e.g., during SEO processing)
 		if ( ! $this->site) {
-			_doing_it_wrong(__METHOD__, esc_html__('setup() or setup_preview() must be called before output().', 'multisite-ultimate'), wu_get_version());
 			return '';
 		}
 

--- a/patches/jasny-sso-php8-compatibility.patch
+++ b/patches/jasny-sso-php8-compatibility.patch
@@ -1,0 +1,26 @@
+--- a/src/Broker/Cookies.php
++++ b/src/Broker/Cookies.php
+@@ -43,6 +43,7 @@ class Cookies implements \ArrayAccess
+     /**
+      * @inheritDoc
+      */
++    #[\ReturnTypeWillChange]
+     public function offsetSet($name, $value)
+     {
+         $success = setcookie($name, $value, time() + $this->ttl, $this->path, $this->domain, $this->secure, true);
+@@ -66,6 +67,7 @@ class Cookies implements \ArrayAccess
+     /**
+      * @inheritDoc
+      */
++    #[\ReturnTypeWillChange]
+     public function offsetGet($name)
+     {
+         return $_COOKIE[$name] ?? null;
+@@ -74,6 +76,7 @@ class Cookies implements \ArrayAccess
+     /**
+      * @inheritDoc
+      */
++    #[\ReturnTypeWillChange]
+     public function offsetExists($name)
+     {
+         return isset($_COOKIE[$name]);


### PR DESCRIPTION
Add defensive null checks in output() method to prevent fatal errors when Slim SEO processes shortcodes before WP Ultimo is fully initialized.

- Add null check for $this->site->get_active_site_url() call
- Add null check for edit_site URL generation using $this->site->get_hash()
- Add null check condition for admin link using $this->site->get_id()

Resolves errors when Current_Site_Element shortcodes are processed during early WordPress initialization phases.

Ref this PR : https://github.com/Multisite-Ultimate/multisite-ultimate/pull/179 and https://github.com/Multisite-Ultimate/multisite-ultimate/pull/159