### PR TITLE
And more options for email verification

### DIFF
--- a/inc/admin-pages/class-settings-admin-page.php
+++ b/inc/admin-pages/class-settings-admin-page.php
@@ -602,7 +602,7 @@ class Settings_Admin_Page extends Wizard_Admin_Page {
 					'style'        => '',
 					'data-on-load' => 'remove_block_ui',
 					'data-wu-app'  => str_replace('-', '_', $section_slug),
-					'data-state'   => wp_json_encode(wu_array_map_keys('wu_replace_dashes', Settings::get_instance()->get_all(true))),
+					'data-state'   => wp_json_encode(wu_array_map_keys('wu_replace_dashes', Settings::get_instance()->get_all_with_defaults(true))),
 				],
 			]
 		);

--- a/inc/checkout/class-checkout.php
+++ b/inc/checkout/class-checkout.php
@@ -812,7 +812,7 @@ class Checkout {
 			/*
 			 * Checks for free memberships.
 			 */
-			if ($this->order->is_free() && $this->order->get_recurring_total() === 0.0 && (! wu_get_setting('enable_email_verification', true) || $this->customer->get_email_verification() !== 'pending')) {
+			if ($this->order->is_free() && $this->order->get_recurring_total() === 0.0 && $this->customer->get_email_verification() !== 'pending') {
 				if ($this->order->get_plan_id() === $this->membership->get_plan_id()) {
 					$this->membership->set_status(Membership_Status::ACTIVE);
 
@@ -829,7 +829,7 @@ class Checkout {
 				$this->membership->set_date_trial_end(gmdate('Y-m-d 23:59:59', $this->order->get_billing_start_date()));
 				$this->membership->set_date_expiration(gmdate('Y-m-d 23:59:59', $this->order->get_billing_start_date()));
 
-				if (wu_get_setting('allow_trial_without_payment_method') && (! wu_get_setting('enable_email_verification', true) || $this->customer->get_email_verification() !== 'pending')) {
+				if (wu_get_setting('allow_trial_without_payment_method') && $this->customer->get_email_verification() !== 'pending') {
 					/*
 					 * In this particular case, we need to set the status to trialing here as we will not update the membership after and then, publish the site.
 					 */

--- a/inc/checkout/class-checkout.php
+++ b/inc/checkout/class-checkout.php
@@ -2259,9 +2259,23 @@ class Checkout {
 	 */
 	public function get_customer_email_verification_status() {
 
-		$should_confirm_email = wu_get_setting('enable_email_verification', true);
+		$email_verification_setting = wu_get_setting('enable_email_verification', 'free_only');
 
-		return $this->order->should_collect_payment() === false && $should_confirm_email ? 'pending' : 'none';
+		switch ($email_verification_setting) {
+			case 'never':
+				return 'none';
+
+			case 'always':
+				return 'pending';
+
+			case 'free_only':
+				return $this->order->should_collect_payment() === false ? 'pending' : 'none';
+
+			default:
+				// Legacy behavior - handle boolean values
+				$should_confirm_email = (bool) $email_verification_setting;
+				return $this->order->should_collect_payment() === false && $should_confirm_email ? 'pending' : 'none';
+		}
 	}
 
 	/**

--- a/inc/class-settings.php
+++ b/inc/class-settings.php
@@ -724,10 +724,15 @@ class Settings {
 			'login-and-registration',
 			'enable_email_verification',
 			[
-				'title'   => __('Enable email verification', 'multisite-ultimate'),
-				'desc'    => __('Enabling this option will require the customer to verify their email address when subscribing to a free plan or a plan with a trial period. Sites will not be created until the customer email verification status is changed to verified.', 'multisite-ultimate'),
-				'type'    => 'toggle',
-				'default' => 1,
+				'title'   => __('Email verification', 'multisite-ultimate'),
+				'desc'    => __('Controls when email verification is required during registration. Sites will not be created until the customer email verification status is changed to verified.', 'multisite-ultimate'),
+				'type'    => 'select',
+				'options' => [
+					'never'     => __('Never require email verification', 'multisite-ultimate'),
+					'free_only' => __('Only for free plans', 'multisite-ultimate'),
+					'always'    => __('Always require email verification', 'multisite-ultimate'),
+				],
+				'default' => 'free_only',
 			]
 		);
 

--- a/inc/models/class-membership.php
+++ b/inc/models/class-membership.php
@@ -2433,7 +2433,7 @@ class Membership extends Base_Model implements Limitable, Billable, Notable {
 
 		// Set trial status if needed
 		if ($this->get_status() === Membership_Status::PENDING && $this->is_trialing() && ! $this->get_last_pending_payment()) {
-			if ( ! wu_get_setting('enable_email_verification', true) || $this->get_customer()->get_email_verification() !== 'pending') {
+			if ($this->get_customer()->get_email_verification() !== 'pending') {
 				$this->set_status(Membership_Status::TRIALING);
 			}
 		}


### PR DESCRIPTION
#194 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tri-state "Email verification" setting added: Never, Only for free orders (default), Always.

* **Behavior Changes**
  * Checkout and membership assignment now evaluate verification according to the new tri-state semantics; free/trial flows no longer rely on the legacy boolean gate.

* **Documentation**
  * Updated label and help text to explain the new options and when verification is enforced.

* **Chores**
  * Preserves backward compatibility by mapping legacy on/off values to the new options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->